### PR TITLE
Liberate from go/imports to fix #7

### DIFF
--- a/internal/asts/asts.go
+++ b/internal/asts/asts.go
@@ -5,8 +5,11 @@ import (
 	"go/ast"
 	"go/build"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+var rNonWord = regexp.MustCompile(`\W`)
 
 type VisitorFunc func(ast.Node) ast.Visitor
 
@@ -102,11 +105,8 @@ func FindPkgPath(file *ast.File, pkgName string) string {
 }
 
 func AssumePkgName(pkgPath string) string {
-	pkg, err := SrcImporter.Import(pkgPath)
-	if err != nil {
-		panic(fmt.Sprintf("goen: unable to assume package name %q: %s", pkgPath, err))
-	}
-	return pkg.Name()
+	n := rNonWord.Split(pkgPath, -1)
+	return n[len(n)-1]
 }
 
 func AssumeImport(dir string) (pkgName string, pkgPath string) {

--- a/internal/asts/asts.go
+++ b/internal/asts/asts.go
@@ -104,7 +104,7 @@ func FindPkgPath(file *ast.File, pkgName string) string {
 func AssumePkgName(pkgPath string) string {
 	bpkg, err := bImport(pkgPath, ".", 0)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("goen: unable to assume package name %q: %s", pkgPath, err))
 	}
 	return bpkg.Name
 }

--- a/internal/asts/asts.go
+++ b/internal/asts/asts.go
@@ -5,11 +5,8 @@ import (
 	"go/ast"
 	"go/build"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
-
-var rNonWord = regexp.MustCompile(`\W`)
 
 type VisitorFunc func(ast.Node) ast.Visitor
 
@@ -105,8 +102,11 @@ func FindPkgPath(file *ast.File, pkgName string) string {
 }
 
 func AssumePkgName(pkgPath string) string {
-	n := rNonWord.Split(pkgPath, -1)
-	return n[len(n)-1]
+	bpkg, err := bImport(pkgPath, ".", 0)
+	if err != nil {
+		panic(err)
+	}
+	return bpkg.Name
 }
 
 func AssumeImport(dir string) (pkgName string, pkgPath string) {

--- a/internal/asts/cacher.go
+++ b/internal/asts/cacher.go
@@ -2,42 +2,8 @@ package asts
 
 import (
 	"go/build"
-	"go/importer"
-	"go/types"
 	"sync"
 )
-
-var (
-	SrcImporter types.Importer = &cachedImporter{
-		// importer.For is deprecated since go1.12
-		// but goen supports older go versions, ignore this line.
-		Importer: importer.For("source", nil), // nolint: staticcheck
-		cache:    map[string]*types.Package{},
-	}
-)
-
-type cachedImporter struct {
-	types.Importer
-
-	mu sync.Mutex
-
-	cache map[string]*types.Package
-}
-
-func (i *cachedImporter) Import(path string) (*types.Package, error) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	if v, ok := i.cache[path]; ok {
-		return v, nil
-	}
-	tpkg, err := i.Importer.Import(path)
-	if err != nil {
-		return nil, err
-	}
-	i.cache[path] = tpkg
-	return tpkg, nil
-}
 
 type bCacheKey struct {
 	Path   string

--- a/internal/asts/parse.go
+++ b/internal/asts/parse.go
@@ -3,14 +3,13 @@ package asts
 import (
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/parser"
 	"go/token"
 )
 
 func ParsePkgPath(pkgPath string) (*ast.Package, error) {
 	// resolve directory of pkg path
-	bpkg, err := bImport(pkgPath, ".", build.FindOnly)
+	bpkg, err := bImport(pkgPath, ".", 0)
 	if err != nil {
 		return nil, err
 	}
@@ -20,7 +19,7 @@ func ParsePkgPath(pkgPath string) (*ast.Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	apkg, ok := apkgs[AssumePkgName(pkgPath)]
+	apkg, ok := apkgs[bpkg.Name]
 	if !ok {
 		return nil, fmt.Errorf("goen: package directory %q is not found", pkgPath)
 	}

--- a/internal/asts/parse.go
+++ b/internal/asts/parse.go
@@ -9,13 +9,8 @@ import (
 )
 
 func ParsePkgPath(pkgPath string) (*ast.Package, error) {
-	// resolve pkgPath as a vendor if possible
-	tpkg, err := SrcImporter.Import(pkgPath)
-	if err != nil {
-		return nil, err
-	}
 	// resolve directory of pkg path
-	bpkg, err := bImport(tpkg.Path(), ".", build.FindOnly)
+	bpkg, err := bImport(pkgPath, ".", build.FindOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +20,7 @@ func ParsePkgPath(pkgPath string) (*ast.Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	apkg, ok := apkgs[tpkg.Name()]
+	apkg, ok := apkgs[AssumePkgName(pkgPath)]
 	if !ok {
 		return nil, fmt.Errorf("goen: package directory %q is not found", pkgPath)
 	}


### PR DESCRIPTION
Just use `go/build` which can handle `GO111MODULE=on` correctly.

At least this changes fixed issues on my environment.